### PR TITLE
Update lager_scribe_backend.erl

### DIFF
--- a/src/lager_scribe_backend.erl
+++ b/src/lager_scribe_backend.erl
@@ -34,7 +34,12 @@ init(Options) ->
         {size, 5},
         {max_overflow, 10}
     ]),
-    {ok, _} = lager_scribe_pool_sup:start_link(ScribeHost, ScribePort, SizeArgs),
+    case lager_scribe_pool_sup:start_link(ScribeHost, ScribePort, SizeArgs) of
+        {ok, _Pid} ->
+            ok;
+        {error, {already_started, _Pid}} ->
+            ok
+    end,
     case validate_loglevel(LevelConfig) of
         false ->
             {error, {fatal, bad_loglevel}};


### PR DESCRIPTION
Нет смысла линковаться с `lager_scribe_pool_sup`, `gen_event` все равно не сдохнит.
Нельзя использовать блокирующие операции, такие как `poolboy:checkout(?POOL_NAME)`
