### PR TITLE
Bump version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
 {deps, [
     {lager, "2.0.3", {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},
     {thrift, "0.8.0", {git, "https://github.com/interline/erlang-thrift.git", "1e0c2d2e529119d18614c16d35f7117469c26099"}, [raw]},
-    {poolboy, "1.1.0", {git, "https://github.com/devinus/poolboy.git", {tag, "1.1.0"}}}
+    {poolboy, "^1\\.", {git, "https://github.com/devinus/poolboy.git", {tag, "1.5.1"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 ]}.
 
 {deps, [
-    {lager, "2.0.3", {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},
+    {lager, "((3|2)\\.|1\\.0|1\\.2).*", {git, "https://github.com/basho/lager.git", {tag, "3.2.0"}}},
     {thrift, "0.8.0", {git, "https://github.com/interline/erlang-thrift.git", "1e0c2d2e529119d18614c16d35f7117469c26099"}, [raw]},
     {poolboy, "^1\\.", {git, "https://github.com/devinus/poolboy.git", {tag, "1.5.1"}}}
 ]}.


### PR DESCRIPTION
lager_scribe_backend совместим lager 3.X и poolboy 1.X
